### PR TITLE
Allow configuring Nuts to trust proxy headers.

### DIFF
--- a/bin/web.js
+++ b/bin/web.js
@@ -5,11 +5,16 @@ var Analytics = require('analytics-node');
 var nuts = require('../');
 
 const
-    BASE_URL = process.env.BASE_URL || '/',
-    PORT     = process.env.PORT || 5000,
-    HOST     = process.env.HOST || '0.0.0.0';
+    BASE_URL    = process.env.BASE_URL || '/',
+    PORT        = process.env.PORT || 5000,
+    HOST        = process.env.HOST || '0.0.0.0'
+    TRUST_PROXY = process.env.TRUST_PROXY || false;
 
 var app = express();
+
+if (TRUST_PROXY) {
+    app.set('trust proxy', true);
+}
 
 var apiAuth =  {
     username: process.env.API_USERNAME,


### PR DESCRIPTION
Setting anything for the TRUST_PROXY environment variable will tell Nuts (or really Express) to look at X-Forwarded-\* headers for information about the request.  This is useful if Nuts is running behind a reverse proxy.
