### PR TITLE
newVersionFilter returns current as well as newer versions

### DIFF
--- a/lib/versions.js
+++ b/lib/versions.js
@@ -14,9 +14,9 @@ function newVersionFilter(opts) {
         // look for anything closer to the main release.
         if (opts.channel) {
             return (opts.channel === version.channel &&
-                    semver.rcompare(version.tag, opts.tag) < 0);
+                    semver.rcompare(version.tag, opts.tag) <= 0);
         } else {
-            return semver.satisfies(version.tag, '>' + opts.tag);
+            return semver.satisfies(version.tag, '>=' + opts.tag);
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuts-serve",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Server to make GitHub releases (private) available to download with Squirrel support",
   "main": "./lib/index.js",
   "homepage": "https://github.com/GitbookIO/nuts",

--- a/test/versions.js
+++ b/test/versions.js
@@ -94,7 +94,7 @@ describe('Versions', function() {
         platform: 'osx',
         channel: undefined
       },
-      expectation: []
+      expectation: ['0.0.7']
     },
     {
       opts: {
@@ -102,7 +102,7 @@ describe('Versions', function() {
         platform: 'osx',
         channel: undefined
       },
-      expectation: ['0.0.7']
+      expectation: ['0.0.7', '0.0.6']
     },
     {
       opts: {
@@ -110,15 +110,7 @@ describe('Versions', function() {
         platform: 'osx',
         channel: undefined
       },
-      expectation: ['0.0.7']
-    },
-    {
-      opts: {
-        tag: '0.0.5',
-        platform: 'osx',
-        channel: undefined
-      },
-      expectation: ['0.0.7', '0.0.6']
+      expectation: ['0.0.7', '0.0.7-beta.1']
     },
     {
       opts: {
@@ -126,7 +118,7 @@ describe('Versions', function() {
         platform: 'osx',
         channel: 'alpha'
       },
-      expectation: ['0.0.8-alpha.1']
+      expectation: ['0.0.8-alpha.1', '0.0.7-alpha.2']
     },
     {
       opts: {
@@ -134,7 +126,7 @@ describe('Versions', function() {
         platform: 'osx',
         channel: 'beta'
       },
-      expectation: []
+      expectation: ['0.0.7-beta.1']
     },
     {
       opts: {
@@ -142,7 +134,7 @@ describe('Versions', function() {
         platform: 'windows',
         channel: 'alpha'
       },
-      expectation: ['0.0.8-alpha.1', '0.0.7-alpha.2']
+      expectation: ['0.0.8-alpha.1', '0.0.7-alpha.2', '0.0.7-alpha.1']
     }
   ]);
 


### PR DESCRIPTION
This is necessary because Squirrel.Windows expects to always get a RELEASES file, and it does the version comparison locally.   The previous way of doing things - only returning a version object if it is newer than the current version (and returning a 204 to the client making the request if there is none) only works for Squirrel.Mac.   Since the calling function in lib/index.js checks to see if the newest returned version is the same as the current version this works just fine for Squirrel.Mac too.
