### PR TITLE
Gracefully close server connections on SIGTERM.

### DIFF
--- a/bin/web.js
+++ b/bin/web.js
@@ -112,3 +112,12 @@ app.use(function(err, req, res, next) {
 var server = app.listen(PORT, HOST, function () {
     console.log('Listening at http://%s:%s%s', HOST, PORT, BASE_URL);
 });
+
+process.on('SIGTERM', function() {
+    // runit sends a SIGTERM, then waits 10 seconds and, if necessary,
+    // sends a SIGKILL.  This lets us shut down gracefully.
+    server.close(function() {
+        console.log('Closed all server connections.');
+        process.exit(0);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuts-serve",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "Server to make GitHub releases (private) available to download with Squirrel support",
   "main": "./lib/index.js",
   "homepage": "https://github.com/GitbookIO/nuts",


### PR DESCRIPTION
This should make it a little safer to restart the server.

relevant:
http://joseoncode.com/2014/07/21/graceful-shutdown-in-node-dot-js/
https://github.com/strongloop/express/issues/1366
