### PR TITLE
Always send fake RELEASES file if requesting it causes an exception

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -219,7 +219,7 @@ module.exports = function nuts(opts) {
             var asset = _.find(latest.platforms, {
                 filename: 'RELEASES'
             });
-            if (!asset) throw new Error("File not found");
+            if (!asset) throw new Error("File not found: RELEASES");
 
            return github.readAsset(asset.download_url)
            .then(function(content) {
@@ -243,7 +243,18 @@ module.exports = function nuts(opts) {
                 res.send(output);
            });
         })
-        .fail(next);
+        .fail(function(error) {
+            // Log the error and return a fake response as if there is no update available.
+            // Prevents Squirrel.Windows crash when it receives a non-2xx response.
+            console.log(error + ' - version: ' + tag);
+
+            var fakeSha = 'da39a3ee5e6b4b0d3255bfef95601890afd80709';
+            var output = [fakeSha, tag, '0'].join(' ');
+
+            res.header('Content-Length', output.length);
+            res.attachment("RELEASES");
+            res.send(output);
+        });
     });
 
     // Get release notes for a specific version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuts-serve",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "Server to make GitHub releases (private) available to download with Squirrel support",
   "main": "./lib/index.js",
   "homepage": "https://github.com/GitbookIO/nuts",


### PR DESCRIPTION
Squirrel.Windows will crash if it gets an error status code from the update server. This stops Nuts from returning 5xx responses when it doesn't really need to. It will allow clients that have a newer local version than anything on the server to run normally without crashing.

Catching things that otherwise would cause a 5xx seems a little janky.  But given the sensitivity of the Windows app to server errors it's probably the best thing we can do.  Ideally we can fix that sensitivity too.