### PR TITLE
Consider localVersion query parameter when determining local version for Windows apps

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -197,7 +197,7 @@ module.exports = function nuts(opts) {
     // Currently, it will only serve a full.nupkg of the latest release with a normalized filename (for pre-release)
     router.get('/update/:platform/:version/RELEASES', function(req, res, next) {
         var platform = 'win_32';
-        var tag = req.params.version;
+        var tag = req.query.localVersion || req.params.version;
         var channel = req.query.channel;
 
         Q()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuts-serve",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "description": "Server to make GitHub releases (private) available to download with Squirrel support",
   "main": "./lib/index.js",
   "homepage": "https://github.com/GitbookIO/nuts",


### PR DESCRIPTION
I noticed a few of these requests in Kibana:

`/release/update/windows/4.3.1/RELEASES?id=Zinc&localVersion=5.0.0&arch=amd64`

Note the `4.3.1` in the path and the `localVersion=5.0.0` in the query string.

If an app has upgraded to 5.0.0, but Nuts thinks it's 4.3.1 it'll respond by saying that 4.3.1 is the latest version.  It should be responding by saying 5.0.0 is the latest version.   This may well be causing problems for Squirrel.

I have no idea why these request paths are being constructed in the first place though.  

